### PR TITLE
Use -q to strip headers for parsing virsh output

### DIFF
--- a/fi-backup.sh
+++ b/fi-backup.sh
@@ -145,7 +145,7 @@ function snapshot_domain() {
          return 1
       fi
       if [ -n "$BACKUP_DIRECTORY" -a -d "$BACKUP_DIRECTORY" ]; then
-         block_devices=$($VIRSH -q -r domblklist "$domain_name" | awk '{print $2}')
+         block_devices=$($VIRSH -q -r domblklist "$domain_name" --details | awk '"disk"==$2 {print $4}')
          _ret=$?
          if [ $_ret -ne 0 ]; then
             print_v e "Error getting block device list for domain '$domain_name'"
@@ -213,7 +213,7 @@ function consolidate_domain() {
    local command_output=
    local parent_backing_file=
 
-   local block_devices=$($VIRSH -q -r domblklist "$domain_name" | awk '/^vd[a-z][[:space:]]+/ {print $2}')
+   local block_devices=$($VIRSH -q -r domblklist "$domain_name" --details | awk '"disk"==$2 {print $4}')
    _ret=$?
    if [ $_ret -ne 0 ]; then
       print_v e "Error getting block device list for domain '$domain_name'"

--- a/fi-backup.sh
+++ b/fi-backup.sh
@@ -213,7 +213,7 @@ function consolidate_domain() {
    local command_output=
    local parent_backing_file=
 
-   local block_devices=$($VIRSH -r domblklist "$domain_name" | awk '/^vd[a-z][[:space:]]+/ {print $2}')
+   local block_devices=$($VIRSH -q -r domblklist "$domain_name" | awk '/^vd[a-z][[:space:]]+/ {print $2}')
    _ret=$?
    if [ $_ret -ne 0 ]; then
       print_v e "Error getting block device list for domain '$domain_name'"

--- a/fi-backup.sh
+++ b/fi-backup.sh
@@ -379,7 +379,7 @@ fi
 
 DOMAINS=
 if [ $DOMAIN_NAME == "all" ]; then
-   DOMAINS=$($VIRSH -r list | tail -n+3 | awk '{print $2;}')
+   DOMAINS=$($VIRSH -q -r list | awk '{print $2;}')
 else
    DOMAINS=$DOMAIN_NAME
 fi

--- a/fi-backup.sh
+++ b/fi-backup.sh
@@ -145,7 +145,7 @@ function snapshot_domain() {
          return 1
       fi
       if [ -n "$BACKUP_DIRECTORY" -a -d "$BACKUP_DIRECTORY" ]; then
-         block_devices=$($VIRSH -r domblklist "$domain_name" | awk '/^[shv]d[a-z][[:space:]]+/ {print $2}')
+         block_devices=$($VIRSH -q -r domblklist "$domain_name" | awk '{print $2}')
          _ret=$?
          if [ $_ret -ne 0 ]; then
             print_v e "Error getting block device list for domain '$domain_name'"


### PR DESCRIPTION
virsh -q will remove the header and --- line so you don't have
to use awk '/...' to only start looking for where to get data.