### PR TITLE
Issue 24:

### DIFF
--- a/fi-backup.sh
+++ b/fi-backup.sh
@@ -650,9 +650,9 @@ for DOMAIN in $DOMAINS_NOTRUNNING; do
 
    if [ $_ret -eq 0 ]; then
       try_lock "$DOMAIN"
-      if [ $? -eq 0 ]; then
+      _ret=$?
+      if [ $_ret -ne 0 ]; then
          print_v e "Another instance of $0 is already running on '$DOMAIN'! Skipping backup of '$DOMAIN'"
-         _ret=1
       fi
    fi
 

--- a/fi-backup.sh
+++ b/fi-backup.sh
@@ -364,6 +364,13 @@ function consolidate_domain() {
    local command_output=
    local parent_backing_file=
 
+   local dom_state=
+   dom_state=$($VIRSH domstate "$domain_name" 2>&1)
+   if [ "$dom_state" != "running" ]; then
+      print_v e "Error: Consolidation requires '$domain_name' to be running"
+      return 1
+   fi
+
    local block_devices=''
    get_block_devices "$domain_name" block_devices
    if [ $? -ne 0 ]; then
@@ -625,6 +632,9 @@ done
 for DOMAIN in $DOMAINS_NOTRUNNING; do
    _ret=0
    declare -a all_backing_files=()
+   if [ $_ret -eq 0 -a $CONSOLIDATION -eq 1 ]; then
+      print_v e "Consolidation only works with running domains. '$DOMAIN' is not running! Doing full backup only of '$DOMAIN'"
+   fi
    try_lock "$DOMAIN"
    if [ $? -eq 0 ]; then
       get_block_devices "$DOMAIN" block_devices


### PR DESCRIPTION
This update clarifies that consolidation is for running domains only.  Changes:

* If only one domain is specified, the script errs out and states that consolidating requires running domains.

* If "all" domains is specified and consolidation is also specified then the running ones are consolidated and the offline ones are backed up normally with an error message generated warning the user of this behavior.

* Shut-off domain backups also require the -b (backup directory) flag to be set. This prevents accidental backing up to the "/" directory. If "all" domains are specified without the -b flag set, the shut-off domains are skipped. 