### PR TITLE
Fix for travisci build fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dist: trusty
 
 install:
   # Install dependencies
-  - sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu/ vivid main universe"
+  - sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu/ xenial main universe"
   - sudo apt-get -y update
   #- sudo apt-get install --reinstall -y -o Dpkg::Options::="--force-confnew" fontconfig fontconfig-config
   - sudo do-release-upgrade -f DistUpgradeViewNonInteractive -m server


### PR DESCRIPTION
Vivid is no longer found in ubuntu repos. Switch to 16.04, xenial